### PR TITLE
TypedObject isNull() now true when value is null

### DIFF
--- a/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
+++ b/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
@@ -239,6 +239,9 @@ public class TypedObject implements Serializable {
      * @return The casted {@link TypedObject}.
      */
     public TypedObject forceCast(Type castedType) {
+        if (value == null) {
+            return NULL;
+        }
         return new TypedObject(castedType, type.forceCast(castedType, value));
     }
 

--- a/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
+++ b/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
@@ -75,12 +75,12 @@ public class TypedObject implements Serializable {
     }
 
     /**
-     * Returns true if the given type is the {@link Type#NULL} type.
+     * Returns true if this TypedObject's type is {@link Type#NULL} or if this TypedObject's value is null.
      *
-     * @return A boolean denoting if the type is {@link Type#NULL}.
+     * @return A boolean denoting if the type is {@link Type#NULL} or if the value is null.
      */
     public boolean isNull() {
-        return Type.isNull(type);
+        return Type.isNull(type) || value == null;
     }
 
     /**
@@ -239,9 +239,6 @@ public class TypedObject implements Serializable {
      * @return The casted {@link TypedObject}.
      */
     public TypedObject forceCast(Type castedType) {
-        if (value == null) {
-            return NULL;
-        }
         return new TypedObject(castedType, type.forceCast(castedType, value));
     }
 
@@ -271,7 +268,7 @@ public class TypedObject implements Serializable {
      * @throws UnsupportedOperationException if the other object could not compared to this.
      */
     public Integer compareTo(TypedObject other) {
-        if (type == Type.NULL || other.type == Type.NULL) {
+        if (isNull() || other.isNull()) {
             return null;
         }
         if (!Type.canCompare(type, other.type)) {

--- a/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
+++ b/src/main/java/com/yahoo/bullet/typesystem/TypedObject.java
@@ -75,7 +75,7 @@ public class TypedObject implements Serializable {
     }
 
     /**
-     * Returns true if this TypedObject's type is {@link Type#NULL} or if this TypedObject's value is null.
+     * Returns true if the type of this TypedObject is {@link Type#NULL} or if the value of this TypedObject is null.
      *
      * @return A boolean denoting if the type is {@link Type#NULL} or if the value is null.
      */

--- a/src/test/java/com/yahoo/bullet/typesystem/TypedObjectTest.java
+++ b/src/test/java/com/yahoo/bullet/typesystem/TypedObjectTest.java
@@ -94,7 +94,7 @@ public class TypedObjectTest {
 
         object = new TypedObject(UNKNOWN, null);
         assertTrue(object.isUnknown());
-        assertFalse(object.isNull());
+        assertTrue(object.isNull());
         assertFalse(object.isList());
         assertFalse(object.isMap());
 
@@ -168,7 +168,7 @@ public class TypedObjectTest {
 
         object = new TypedObject(Type.STRING_MAP_MAP, null);
         assertFalse(object.isUnknown());
-        assertFalse(object.isNull());
+        assertTrue(object.isNull());
         assertFalse(object.isPrimitive());
         assertFalse(object.isList());
         assertTrue(object.isMap());
@@ -177,7 +177,7 @@ public class TypedObjectTest {
 
         object = new TypedObject(Type.BOOLEAN_MAP_LIST, null);
         assertFalse(object.isUnknown());
-        assertFalse(object.isNull());
+        assertTrue(object.isNull());
         assertFalse(object.isPrimitive());
         assertFalse(object.isMap());
         assertTrue(object.isList());
@@ -516,13 +516,6 @@ public class TypedObjectTest {
         assertEquals(object.forceCast(Type.BOOLEAN).getValue(), false);
     }
 
-    @Test
-    public void testForceCastNull() {
-        TypedObject object = new TypedObject(null);
-        assertEquals(object.forceCast(INTEGER).getType(), NULL);
-        assertNull(object.forceCast(INTEGER).getValue());
-    }
-
     @Test(expectedExceptions = ClassCastException.class)
     public void testForceCastToUnsupportedType() {
         TypedObject object = new TypedObject(1);
@@ -691,7 +684,7 @@ public class TypedObjectTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnknownComparison() {
-        TypedObject objectA = new TypedObject(UNKNOWN, null);
+        TypedObject objectA = new TypedObject(UNKNOWN, 5);
         TypedObject objectB = new TypedObject(42.1);
         objectA.compareTo(objectB);
     }

--- a/src/test/java/com/yahoo/bullet/typesystem/TypedObjectTest.java
+++ b/src/test/java/com/yahoo/bullet/typesystem/TypedObjectTest.java
@@ -516,6 +516,13 @@ public class TypedObjectTest {
         assertEquals(object.forceCast(Type.BOOLEAN).getValue(), false);
     }
 
+    @Test
+    public void testForceCastNull() {
+        TypedObject object = new TypedObject(null);
+        assertEquals(object.forceCast(INTEGER).getType(), NULL);
+        assertNull(object.forceCast(INTEGER).getValue());
+    }
+
     @Test(expectedExceptions = ClassCastException.class)
     public void testForceCastToUnsupportedType() {
         TypedObject object = new TypedObject(1);


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Before, force casting a null to LONG, for example, would return a new TypedObject(Type.LONG, null) which is incorrect and causes some evaluators to throw when they shouldn't. 