### PR TITLE
Makes copying an Avro record not serialize/reify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.yahoo.bullet</groupId>
     <artifactId>bullet-record</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>bullet-record</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.yahoo.bullet</groupId>
     <artifactId>bullet-record</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>bullet-record</name>
     <description>

--- a/src/main/java/com/yahoo/bullet/record/avro/LazyBulletAvro.java
+++ b/src/main/java/com/yahoo/bullet/record/avro/LazyBulletAvro.java
@@ -46,17 +46,19 @@ public class LazyBulletAvro implements Serializable, Iterable<Map.Entry<String, 
     protected transient boolean isDeserialized = true;
 
     /**
-     * Copy constructor.
+     * Shallow copy constructor.
      *
      * @param other The {@link LazyBulletAvro} to copy.
      * @throws RuntimeException if failed to copy data from the source.
      */
     public LazyBulletAvro(LazyBulletAvro other) {
         try {
-            serializedData = other.getAsByteArray();
-            isDeserialized = false;
+            other.forceFailIfCannotRead();
+            serializedData = null;
+            data = new HashMap<>(other.data);
+            isDeserialized = true;
         } catch (Exception e) {
-            log.error("Unable to serialize the other record", e);
+            log.error("Unable to read data from the other record", e);
             throw new RuntimeException(e);
         }
     }
@@ -298,12 +300,5 @@ public class LazyBulletAvro implements Serializable, Iterable<Map.Entry<String, 
         serializedData = (byte[]) in.readObject();
         data = null;
         isDeserialized = false;
-    }
-
-    private byte[] getAsByteArray() throws IOException {
-        if (isDeserialized) {
-            return serialize(data);
-        }
-        return serializedData;
     }
 }

--- a/src/test/java/com/yahoo/bullet/record/avro/LazyBulletAvroTest.java
+++ b/src/test/java/com/yahoo/bullet/record/avro/LazyBulletAvroTest.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.bullet.record.avro;
 
-import com.yahoo.bullet.typesystem.Type;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
@@ -83,7 +82,8 @@ public class LazyBulletAvroTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testFailCopying() {
-        avro.set("foo", Type.NULL);
+        avro.serializedData = new byte[0];
+        avro.isDeserialized = false;
         avro.copy();
     }
 
@@ -94,9 +94,11 @@ public class LazyBulletAvroTest {
         LazyBulletAvro copyOfCopy = new LazyBulletAvro(copy);
         LazyBulletAvro copyOfCopyOfCopy = copyOfCopy.copy();
         Assert.assertEquals(copyOfCopy.get("someField"), "someValue");
-        Assert.assertEquals(copyOfCopy.fieldCount(), 1);
+        copyOfCopy.set("someOtherField", "someOtherValue");
+        Assert.assertEquals(copyOfCopy.fieldCount(), 2);
         Assert.assertEquals(copyOfCopyOfCopy.get("someField"), "someValue");
         Assert.assertEquals(copyOfCopyOfCopy.fieldCount(), 1);
+        Assert.assertEquals(avro.fieldCount(), 1);
     }
 
     @Test


### PR DESCRIPTION
Now the copy of an Avro record is a shallow copy.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
